### PR TITLE
Patch the datadog_reports process to allow hostname munging.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -207,8 +207,8 @@ class datadog_agent(
 
   if $puppet_run_reports {
     class { 'datadog_agent::reports':
-      api_key           => $api_key,
-      puppetmaster_user => $puppetmaster_user,
+      api_key                   => $api_key,
+      puppetmaster_user         => $puppetmaster_user,
       hostname_extraction_regex => $hostname_extraction_regex,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,11 @@
 #   $log_level
 #       Set value of 'log_level' variable. Default is 'info' as in dd-agent.
 #       Valid values here are: critical, debug, error, fatal, info, warn and warning.
+#   $hostname_extraction_regex
+#       Completely optional.
+#       Instead of reporting the puppet nodename, use this regex to extract the named
+#       'hostname' captured group to report the run in Datadog.
+#       ex.: '^(?<hostname>.*\.reachlocal\.com)(\.i-\w{8}\..*)?$'
 #   $log_to_syslog
 #       Set value of 'log_to_syslog' variable. Default is true -> yes as in dd-agent.
 #       Valid values here are: true or false.
@@ -103,6 +108,7 @@ class datadog_agent(
   $log_to_syslog = true,
   $service_ensure = 'running',
   $service_enable = true,
+  $hostname_extraction_regex = '',
   $use_mount = false,
   $dogstatsd_port = 8125,
   $statsd_forward_host = '',
@@ -203,6 +209,7 @@ class datadog_agent(
     class { 'datadog_agent::reports':
       api_key           => $api_key,
       puppetmaster_user => $puppetmaster_user,
+      hostname_extraction_regex => $hostname_extraction_regex,
     }
   }
 

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -15,7 +15,8 @@
 #
 class datadog_agent::reports(
   $api_key,
-  $puppetmaster_user
+  $puppetmaster_user,
+  $hostname_extraction_regex
 ) {
 
   include datadog_agent::params

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -16,7 +16,7 @@
 class datadog_agent::reports(
   $api_key,
   $puppetmaster_user,
-  $hostname_extraction_regex
+  $hostname_extraction_regex = nil,
 ) {
 
   include datadog_agent::params

--- a/templates/datadog.yaml.erb
+++ b/templates/datadog.yaml.erb
@@ -3,3 +3,4 @@
 #
 ---
 :datadog_api_key: '<%= @api_key %>'
+:hostname_extraction_regex: '<%= @hostname_extraction_regex %>'

--- a/templates/datadog.yaml.erb
+++ b/templates/datadog.yaml.erb
@@ -3,4 +3,4 @@
 #
 ---
 :datadog_api_key: '<%= @api_key %>'
-:hostname_extraction_regex: '<%= @hostname_extraction_regex %>'
+<% if @hostname_extraction_regex -%>:hostname_extraction_regex: '<%= @hostname_extraction_regex %>'<% end %>


### PR DESCRIPTION
When you have puppet "node name" that isn't JUST a hostname, you need to
be able to tell the report processor to munge the hostname a bit. This
patch was taken directly from
https://gist.github.com/LeoCavaille/264d0f7cf27b0d7e2bb3 and is the
recommended patch to use by Datadog.
