### PR TITLE
skip_apt_key_trusting to check for false boolean

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -24,7 +24,8 @@ class datadog_agent::ubuntu(
   ensure_packages(['apt-transport-https'])
   validate_array($other_keys)
 
-  if ! defined('$::datadog_agent::skip_apt_key_trusting') {
+  if defined('$::datadog_agent::skip_apt_key_trusting') and (
+      any2bool($::datadog_agent::skip_apt_key_trusting) == false) {
     $mykeys = concat($other_keys, [$apt_key])
 
     ::datadog_agent::ubuntu::install_key { $mykeys:


### PR DESCRIPTION
Test run in packer:
```
    amazon-ebs: puppet_run: Debug: Executing '/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 935F5A436A5A6E8788F0765B226AE980C7A7DA52'
    amazon-ebs: puppet_run: Notice: /Stage[main]/Datadog_agent::Ubuntu/Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52]/Exec[key 935F5A436A5A6E8788F0765B226AE980C7A7DA52]/returns: Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --homedir /tmp/tmp.bZ48DuLaGO --no-auto-check-trustdb --trust-model always --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyring /etc/apt/trusted.gpg.d/saiarcot895-myppa.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 935F5A436A5A6E8788F0765B226AE980C7A7DA52
    amazon-ebs: puppet_run: Notice: /Stage[main]/Datadog_agent::Ubuntu/Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52]/Exec[key 935F5A436A5A6E8788F0765B226AE980C7A7DA52]/returns: gpg: requesting key C7A7DA52 from hkp server keyserver.ubuntu.com
    amazon-ebs: puppet_run: Notice: /Stage[main]/Datadog_agent::Ubuntu/Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52]/Exec[key 935F5A436A5A6E8788F0765B226AE980C7A7DA52]/returns: gpg: key C7A7DA52: public key "Datadog Packages <package@datadoghq.com>" imported
    amazon-ebs: puppet_run: Notice: /Stage[main]/Datadog_agent::Ubuntu/Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52]/Exec[key 935F5A436A5A6E8788F0765B226AE980C7A7DA52]/returns: gpg: Total number processed: 1
    amazon-ebs: puppet_run: Notice: /Stage[main]/Datadog_agent::Ubuntu/Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52]/Exec[key 935F5A436A5A6E8788F0765B226AE980C7A7DA52]/returns: gpg:               imported: 1  (RSA: 1)
    amazon-ebs: puppet_run: Notice: /Stage[main]/Datadog_agent::Ubuntu/Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52]/Exec[key 935F5A436A5A6E8788F0765B226AE980C7A7DA52]/returns: executed successfully
    amazon-ebs: puppet_run: Debug: /Stage[main]/Datadog_agent::Ubuntu/Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52]/Exec[key 935F5A436A5A6E8788F0765B226AE980C7A7DA52]: The container Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52] will propagate my refresh event
    amazon-ebs: puppet_run: Debug: Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52]: The container Class[Datadog_agent::Ubuntu] will propagate my refresh event
```